### PR TITLE
Fixes for running ggj20 on Macs

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8,6 +8,7 @@ void initSDLAudioPlugin(IPluginRegistry &registry);
 void initSDLInputPlugin(IPluginRegistry &registry);
 void initDX11Plugin(IPluginRegistry &registry);
 void initAsioPlugin(IPluginRegistry &registry);
+void initMetalPlugin(IPluginRegistry &registry);
 
 void GGJ20Game::init(const Environment& env, const Vector<String>& args)
 {
@@ -15,14 +16,18 @@ void GGJ20Game::init(const Environment& env, const Vector<String>& args)
 
 int GGJ20Game::initPlugins(IPluginRegistry& registry)
 {
-	initOpenGLPlugin(registry);
 	initSDLSystemPlugin(registry, {});
 	initSDLAudioPlugin(registry);
 	initSDLInputPlugin(registry);
 
 #ifdef WITH_DX11
 	initDX11Plugin(registry);
-#endif
+#elif __APPLE__
+	initMetalPlugin(registry);
+#else
+	initOpenGLPlugin(registry);
+#endif;
+
 #ifdef WITH_ASIO
 	initAsioPlugin(registry);
 #endif

--- a/src/services/input_service.cpp
+++ b/src/services/input_service.cpp
@@ -4,8 +4,8 @@ InputService::InputService(InputAPI& input)
 {
 	device = std::make_shared<InputVirtual>(12, 2);
 
-	auto key = input.getKeyboard();
-	if (key) {
+	if (input.getNumberOfKeyboards() > 0) {
+		auto key = input.getKeyboard();
 		device->bindButton(0, key, Keys::S);
 		device->bindButton(1, key, Keys::D);
 		device->bindButton(2, key, Keys::A);
@@ -19,9 +19,9 @@ InputService::InputService(InputAPI& input)
 		device->bindButton(4, key, Keys::Enter);
 		device->bindButton(4, key, Keys::KP_Enter);
 	}
-	
-	auto joy = input.getJoystick();
-	if (joy) {
+
+	if (input.getNumberOfJoysticks() > 0) {
+		auto joy = input.getJoystick();
 		device->bindButton(0, joy, joy->getButtonAtPosition(JoystickButtonPosition::FaceBottom));
 		device->bindButton(1, joy, joy->getButtonAtPosition(JoystickButtonPosition::FaceRight));
 		device->bindButton(2, joy, joy->getButtonAtPosition(JoystickButtonPosition::FaceLeft));


### PR DESCRIPTION
- Use Metal if we're on a Mac instead of OpenGL
- Properly check whether we have a keyboard and/or joystick before binding it.